### PR TITLE
Draft: Zig build ncurses

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -45,13 +45,18 @@ pub fn build(b: *std.Build) void {
     });
 
     if (!use_system_ncurses) ncurses: {
-        const ncurses_dep = b.lazyDependency("ncurses", .{}) orelse break :ncurses;
+        // These are settings used by release process
+        // (for tarballs with static binary)
+        const ncurses_dep = b.lazyDependency("ncurses", .{
+            .target = target,
+            .optimize = optimize,
 
-        const ncurses = buildNcurses(b, ncurses_dep, target.result, pie);
-        t.run.step.dependOn(&ncurses.step.step);
-        t.addIncludePath(ncurses.inst_dir.path(b, "include/ncursesw"));
-        t.addIncludePath(ncurses.inst_dir.path(b, "include"));
-        main_mod.addObjectFile(ncurses.inst_dir.path(b, "lib/libncursesw.a"));
+            .linkage = .static,
+            .@"no-widechar" = false,
+        }) orelse break :ncurses;
+        const ncurses_lib = ncurses_dep.artifact("ncurses");
+        t.addIncludePath(ncurses_lib.getEmittedIncludeTree());
+        main_mod.linkLibrary(ncurses_lib);
     }
 
     if (!use_system_zstd) zstd: {
@@ -112,141 +117,4 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
-}
-
-fn gnuFormat(gpa: std.mem.Allocator, target: std.Target) []const u8 {
-    var aw: std.Io.Writer.Allocating = .init(gpa);
-    defer aw.deinit();
-
-    const arch_str = switch (target.cpu.arch) {
-        .bpfel => "bpf",
-        .thumb => "arm",
-        .thumbeb => "armeb",
-        // Same or untested
-        else => |same| @tagName(same),
-    };
-
-    const os_str = switch (target.os.tag) {
-        else => |same| @tagName(same),
-    };
-
-    const abi_str = switch (target.abi) {
-        else => |same| if (target.os.tag == .macos)
-            "darwin"
-        else
-            @tagName(same),
-    };
-
-    return std.fmt.allocPrint(gpa, "{s}-{s}-{s}", .{ arch_str, os_str, abi_str }) catch @panic("OOM");
-}
-
-fn zigFormat(gpa: std.mem.Allocator, target: std.Target) []const u8 {
-    return target.zigTriple(gpa) catch @panic("OOM");
-}
-
-const NcursesResult = struct {
-    step: *std.Build.Step.Run,
-    inst_dir: std.Build.LazyPath,
-};
-
-// https://ziggit.dev/t/running-a-configure-script-as-a-build-step-trying-to-build-hdf5/5540/2
-// https://ziggit.dev/t/migrating-from-autotools-to-zig-build/7580/3
-// TODO: try to find more feature-ful packaged Zig build system support for ncurses.
-// Something like https://github.com/allyourcodebase/zstd in our root project dependencies...
-
-/// This is package for dealing with fetched Ncurses library, in case ncdu is being built
-/// without system library integration enabled, or when making static tarball release.
-fn buildNcurses(
-    b: *std.Build,
-    ncurses_dep: *std.Build.Dependency,
-    target: std.Target,
-    pie: ?bool,
-) NcursesResult {
-    const target_gnu_format = gnuFormat(b.graph.arena, target);
-    const target_zig_format = zigFormat(b.graph.arena, target);
-
-    const host_gnu_format = gnuFormat(b.graph.arena, b.graph.host.result);
-    const host_zig_format = zigFormat(b.graph.arena, b.graph.host.result);
-
-    const ncurses_cache = b.addNamedWriteFiles(b.fmt("ncurses-{s}", .{target_zig_format}));
-    const cwd = ncurses_cache.getDirectory();
-
-    const run_config = std.Build.Step.Run.create(b, "configure fetched ncurses");
-    run_config.setCwd(cwd);
-    run_config.addFileArg(ncurses_dep.path("configure"));
-    const prefix_dir = run_config.addPrefixedOutputDirectoryArg("--prefix=", "inst");
-
-    run_config.addArgs(&.{
-        // We need minimized and static build, so disable unneccessary stuff:
-
-        "--without-cxx",
-        "--without-cxx-binding",
-        "--without-ada",
-        "--without-manpages",
-        "--without-progs",
-        "--without-tests",
-        "--disable-pc-files",
-        "--disable-db-install",
-        "--without-pkg-config",
-        "--without-shared",
-        "--without-debug",
-        "--without-gpm",
-        "--without-sysmouse",
-        "--enable-widec",
-        "--with-default-terminfo-dir=/usr/share/terminfo",
-        "--with-terminfo-dirs=/usr/share/terminfo:/lib/terminfo:/usr/local/share/terminfo",
-        "--with-fallbacks=screen linux vt100 xterm xterm-256color",
-    });
-
-    // Set info for cross-compilation itself
-    run_config.addArgs(&.{
-        b.fmt("--host={s}", .{host_gnu_format}),
-        b.fmt("--build={s}", .{target_gnu_format}),
-    });
-
-    const zig_cc = b.fmt("{s} cc", .{b.graph.zig_exe});
-    const zig_ar = b.fmt("{s} ar", .{b.graph.zig_exe});
-    const zig_ranlib = b.fmt("{s} ranlib", .{b.graph.zig_exe});
-
-    run_config.setEnvironmentVariable("BUILD_CC", b.fmt("{s} --target={s}", .{ zig_cc, host_zig_format }));
-    run_config.setEnvironmentVariable("BUILD_LD", b.fmt("{s} --target={s}", .{ zig_cc, host_zig_format }));
-
-    run_config.setEnvironmentVariable("CC", b.fmt("{s} --target={s}", .{ zig_cc, target_zig_format }));
-    run_config.setEnvironmentVariable("LD", b.fmt("{s} --target={s}", .{ zig_cc, target_zig_format }));
-    run_config.setEnvironmentVariable("AR", zig_ar);
-    run_config.setEnvironmentVariable("RANLIB", zig_ranlib);
-
-    const cflags = std.mem.join(b.graph.arena, " ", &.{
-        b.fmt("--target={s}", .{target_zig_format}),
-        "-O2",
-        if (pie orelse false)
-            "-fPIC"
-        else
-            "",
-    }) catch @panic("OOM");
-    const ldflags = b.fmt("--target={s}", .{target_zig_format});
-
-    run_config.setEnvironmentVariable("CPPFLAGS", "-D_GNU_SOURCE");
-    run_config.setEnvironmentVariable("CFLAGS", cflags);
-    run_config.setEnvironmentVariable("LDFLAGS", ldflags);
-
-    // Debugging:
-    // run_config.stdio = .inherit;
-    // run_config.setStdIn(.none);
-
-    const run_make = std.Build.Step.Run.create(b, "build fetched ncurses");
-    run_make.setCwd(cwd);
-    run_make.step.dependOn(&run_config.step);
-
-    const make_jobs = b.graph.max_jobs orelse 8;
-    run_make.addArgs(&.{ "make", b.fmt("-j{d}", .{make_jobs}), "install" });
-
-    // Debugging:
-    // run_make.stdio = .inherit;
-    // run_make.setStdIn(.none);
-
-    return .{
-        .step = run_make,
-        .inst_dir = prefix_dir,
-    };
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,8 +22,8 @@
             .lazy = true,
         },
         .ncurses = .{
-            .url = "https://ftp.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz",
-            .hash = "N-V-__8AAMZOFwGYoq9VA4jW9LOy4Ud9bufE7x2ep88NNqFr",
+            .url = "git+https://github.com/dasimmet/ncurses.git#3f321d565df8df3c10b2671fba93a8f0ea7cc40a",
+            .hash = "ncurses-6.5.20240427-mGIXmPcPAwDWmbmR6swaucKSiizyJ8Uo3H4OGKfFDVOA",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,8 +22,8 @@
             .lazy = true,
         },
         .ncurses = .{
-            .url = "git+https://github.com/dasimmet/ncurses.git#3f321d565df8df3c10b2671fba93a8f0ea7cc40a",
-            .hash = "ncurses-6.5.20240427-mGIXmPcPAwDWmbmR6swaucKSiizyJ8Uo3H4OGKfFDVOA",
+            .url = "git+https://github.com/dasimmet/ncurses.git#4193b4fe8fabd2f29f4e4630661738d758e8bb28",
+            .hash = "ncurses-6.5.20240427-mGIXmJvvAQBlDlgZ5gZ2bVNHoVQrpMEIA8U5mUNNv_Bz",
             .lazy = true,
         },
     },


### PR DESCRIPTION
I managed to get it to build and look the same using my ncurses zig build now.
There used to be a false "USE_TERM_DRIVER" define active on posix oses.

however, my nurses build is a bit of a shortcut since a few generated c sources are commited to the repository:
<https://github.com/dasimmet/ncurses/tree/main/src/c>

especially the `lib_gen.c` is quite difficult to generate without the shellscript that autoconf uses,
as it uses a combination of the c preprocessor and awk, so there's no guarantee that it might work for a variety of build configurations.
